### PR TITLE
Update header.svelte

### DIFF
--- a/packages/docs/src/routes/header.svelte
+++ b/packages/docs/src/routes/header.svelte
@@ -28,7 +28,7 @@
 	})
 </script>
 
-<nav>
+<nav class="mx-[-2.4rem] px-[2.4rem]>
 	<div class="space-between container">
 		<div class="left-side">
 			<div class="space-x" style:--margin="var(--size-0)">


### PR DESCRIPTION
The padding on the body is causing the background blur of the header to not be fully visible. I came up with a simple solution, but maybe would it be better if no padding is applied to the body.

![Frame 134](https://github.com/animotionjs/animotion/assets/25558870/2867ddad-ab4b-43bf-af0c-e5157ba49f2c)
