### PR TITLE
Add `history` option to persist slide state across page reloads

### DIFF
--- a/packages/animotion/src/routes/+page.svelte
+++ b/packages/animotion/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 	let layout = $state('flex gap-4')
 </script>
 
-<Presentation options={{ history: true, transition: 'slide', controls: true, progress: true, hash: false }}>
+<Presentation options={{ history: true, transition: 'slide', controls: true, progress: true }}>
 	<Slide on:out={() => circle.reset()} class="h-full place-content-center place-items-center">
 		<Transition>
 			<p bind:this={text} class="text-8xl font-bold drop-shadow-sm">🪄 Animotion</p>

--- a/packages/animotion/src/routes/+page.svelte
+++ b/packages/animotion/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 	let layout = $state('flex gap-4')
 </script>
 
-<Presentation options={{ transition: 'slide', controls: true, progress: true, hash: false }}>
+<Presentation options={{ history: true, transition: 'slide', controls: true, progress: true, hash: false }}>
 	<Slide on:out={() => circle.reset()} class="h-full place-content-center place-items-center">
 		<Transition>
 			<p bind:this={text} class="text-8xl font-bold drop-shadow-sm">🪄 Animotion</p>

--- a/packages/create/template/src/routes/+page.svelte
+++ b/packages/create/template/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 	let layout = $state('flex gap-4')
 </script>
 
-<Presentation options={{ transition: 'slide', controls: true, progress: true, hash: false }}>
+<Presentation options={{ history: true, transition: 'slide', controls: true, progress: true }}>
 	<Slide on:out={() => circle.reset()} class="h-full place-content-center place-items-center">
 		<Transition>
 			<p bind:this={text} class="text-8xl font-bold drop-shadow-sm">🪄 Animotion</p>


### PR DESCRIPTION

**Description:**

solves https://github.com/animotionjs/animotion/issues/31

**Problem:**
When editing a presentation with Reveal.js and saving changes, the presentation always reloads back to the beginning. This behavior can be disruptive, especially when working on longer presentations, as it requires manually navigating back to the slide being edited.

**Solution:**
Add the `history` option to the Reveal.js initialization configuration. The `history` option helps preserve the state of the current slide across page reloads, allowing users to continue from where they left off.

**Proposed Configuration:**
```jsx
<Presentation
    options={{ history: true, transition: 'slide', controls: true, progress: true, hash: false }}
>
```

**Rationale:**
Enabling the `history` option will significantly enhance the user experience by maintaining the current slide state during development and editing, thus improving workflow efficiency.

**Additional Context:**
The `history` option utilizes the browser's history API to store the current slide number. This small addition can make a big difference in usability without affecting other functionalities.

---

Feel free to adjust the content as needed before submitting the pull request.