### PR TITLE
fix: widen peer dependencies on svelte 5

### DIFF
--- a/packages/animotion/package.json
+++ b/packages/animotion/package.json
@@ -75,6 +75,6 @@
 		"tailwindcss": "4.0.0-alpha.15"
 	},
 	"peerDependencies": {
-		"svelte": "5.0.0-next.167"
+		"svelte": "^5.0.0 || ^5.0.0-next.1"
 	}
 }


### PR DESCRIPTION
The current peer dependency is way to strict as it only allow for a specific version of a release candidate svelte 5 version. The proposed change widen that peer to allow for any release candidate and the actual 5 release (for when it will be out).

One consideration should be if you are using something that has been released only at a later point in the `next` series we might want to bump from `^5.0.0-next.1` to the minimum version your lib actually require.