### PR TITLE
fix: add default and import exports

### DIFF
--- a/packages/animotion/package.json
+++ b/packages/animotion/package.json
@@ -33,7 +33,9 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"svelte": "./dist/index.js",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
 		},
 		"./theme": "./dist/styles/theme.css"
 	},


### PR DESCRIPTION
This will fix `vite` erroring out when trying to import `defineProps`