### PR TITLE
fix: import `defineProps` separately to allow import in module

### DIFF
--- a/packages/animotion/package.json
+++ b/packages/animotion/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@animotion/core",
-	"version": "1.0.20",
+	"version": "1.0.21",
 	"description": "Core components for Animotion",
 	"author": "animotionjs",
 	"homepage": "https://animotion.pages.dev/",

--- a/packages/animotion/src/lib/components/index.ts
+++ b/packages/animotion/src/lib/components/index.ts
@@ -7,17 +7,5 @@ import Recorder from './recorder.svelte'
 import Slide from './slide.svelte'
 import Slides from './slides.svelte'
 import Transition from './transition.svelte'
-import { defineProps } from './props.js'
 
-export {
-	Action,
-	Code,
-	Embed,
-	Notes,
-	Presentation,
-	Recorder,
-	Slide,
-	Slides,
-	Transition,
-	defineProps
-}
+export { Action, Code, Embed, Notes, Presentation, Recorder, Slide, Slides, Transition }

--- a/packages/animotion/src/lib/components/props.ts
+++ b/packages/animotion/src/lib/components/props.ts
@@ -1,5 +1,5 @@
 import type { Component, ComponentProps } from 'svelte'
-import Slide from './slide.svelte'
+import type Slide from './slide.svelte'
 
 type Props<T extends Component> = { component?: T } & ComponentProps<T>
 

--- a/packages/animotion/src/lib/index.ts
+++ b/packages/animotion/src/lib/index.ts
@@ -1,1 +1,2 @@
+export { defineProps } from './components/props.js'
 export * from './components/index.js'

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -39,7 +39,7 @@
 		"vite": "^5.4.8"
 	},
 	"dependencies": {
-		"@animotion/core": "^1.0.20",
+		"@animotion/core": "^1.0.21",
 		"@animotion/motion": "^1.0.1",
 		"@fontsource-variable/jetbrains-mono": "^5.0.21",
 		"@fontsource-variable/manrope": "^5.0.20",

--- a/packages/docs/src/routes/docs/file-based/+page.md
+++ b/packages/docs/src/routes/docs/file-based/+page.md
@@ -43,10 +43,12 @@ If you need to pass props to the `<Slide>` use `<script module>`:
 
 ```svelte
 <script module>
-	export const props = {
+	import { defineProps } from '@animotion/core'
+
+	export const props = defineProps({
 		in: () => alert('in'),
 		out: () => alert('out')
-	}
+	})
 </script>
 
 <!-- /slides/100/slide.svelte -->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,8 +105,8 @@ importers:
   packages/docs:
     dependencies:
       '@animotion/core':
-        specifier: ^1.0.20
-        version: 1.0.20(svelte@5.0.0-next.260)(vite@5.4.8(lightningcss@1.27.0))
+        specifier: ^1.0.21
+        version: 1.0.21(svelte@5.0.0-next.260)(vite@5.4.8(lightningcss@1.27.0))
       '@animotion/motion':
         specifier: ^1.0.1
         version: 1.0.1(svelte@5.0.0-next.260)
@@ -211,8 +211,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@animotion/core@1.0.20':
-    resolution: {integrity: sha512-fUZrHSNEKCm/TxElkcfX8WRakIfAVFFc24kOZCBeTalPbHLdIRLKS+dXqbgCf0j6K6KaxS/iVw9edu7Azk1jyw==}
+  '@animotion/core@1.0.21':
+    resolution: {integrity: sha512-a0g57HI3g1IYv9zxvbt815bgcdX5L3it0ACrq+c0CuIRSDoh3i6RJdx22t77gETSiuVkW1VG6sF8Tl8urQZGwQ==}
     peerDependencies:
       svelte: ^5.0.0 || ^5.0.0-next.1
 
@@ -2658,7 +2658,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@animotion/core@1.0.20(svelte@5.0.0-next.260)(vite@5.4.8(lightningcss@1.27.0))':
+  '@animotion/core@1.0.21(svelte@5.0.0-next.260)(vite@5.4.8(lightningcss@1.27.0))':
     dependencies:
       '@animotion/motion': 1.0.1(svelte@5.0.0-next.260)
       '@fontsource-variable/jetbrains-mono': 5.1.0


### PR DESCRIPTION
As per title...the problem is that `import.meta.glob` with eager get's converted to a series of static `import`...this means that as soon as you imported something from `@animotion/core` the module resolution would've:

1. imported index
2. imported /components/index
3. imported /components/slides
4. in there imported the slide component with `import.meta.glob` before the `defineProps` import...so it was undefined

I moved the export to the root index before the export * so that now it's immediately defined (p.s. i've also changed the `defineProps` to only import the type of Slide).