### PR TITLE
feat: support data-autoslide on slide and transition

### DIFF
--- a/packages/animotion/src/lib/components/slide.svelte
+++ b/packages/animotion/src/lib/components/slide.svelte
@@ -10,6 +10,7 @@
 		animateUnmatched?: boolean
 		animateId?: string
 		animateRestart?: boolean
+		stepDuration?: number
 		background?: string
 		gradient?: string
 		image?: string
@@ -35,6 +36,7 @@
 	data-auto-animate-unmatched={props.animateUnmatched}
 	data-auto-animate-id={props.animateId}
 	data-auto-animate-restart={props.animateRestart}
+	data-autoslide={props.stepDuration}
 	data-background-color={props.background}
 	data-background-gradient={props.gradient}
 	data-background-image={props.image}

--- a/packages/animotion/src/lib/components/transition.svelte
+++ b/packages/animotion/src/lib/components/transition.svelte
@@ -7,6 +7,7 @@
 		undo?: () => void
 		class?: string
 		order?: number
+		stepDuration?: number
 		name?: string
 		enter?: string
 		visible?: boolean
@@ -17,6 +18,7 @@
 	let {
 		children,
 		order,
+		stepDuration,
 		name,
 		enter = 'enter',
 		visible = false,
@@ -83,6 +85,7 @@
 	class:fragment={!visible}
 	class={props.class}
 	data-fragment-index={order}
+	data-autoslide={stepDuration}
 	style:view-transition-name={viewTransitionName}
 >
 	{#if children}


### PR DESCRIPTION
At the moment, it's possible to pass a value for `autoSlide` as a prop in the `Presentation` component.
However, as far as I was can tell, there is no fine-grained control over the `Slide` and `Transition` (section and fragment) autoslide duration.

Passing a `stepDuration` value (in milliseconds) to `Slide` or `Transition` overrides the general autoSlide duration for all transitions in a slide or the display duration of a specific transition.

revealjs docs: https://revealjs.com/auto-slide/#slide-timing
Together with the `loop`-option, this makes for a great kiosk presentation.

(I opted not to just pass all the additional props like how it's done with `Presentation` since some revealjs attributes were already declared as props in both components; However this might be something to think about, since it will possibly make new revealjs features work out-of-box without additional code)