### PR TITLE
fix: Tailwind deps

### DIFF
--- a/packages/create/template/package.json
+++ b/packages/create/template/package.json
@@ -29,8 +29,8 @@
 		"@animotion/motion": "*",
 		"@fontsource/atkinson-hyperlegible": "^5.1.1",
 		"@fontsource/monaspace-neon": "^5.1.0",
-		"@tailwindcss/vite": "4.0.0",
+		"@tailwindcss/vite": "^4.0.0",
 		"reveal.js": "^5.1.0",
-		"tailwindcss": "4.0.0"
+		"tailwindcss": "^4.0.0"
 	}
 }


### PR DESCRIPTION
Allow any `4.x.x` version of tailwind dependencies. 

Fixes #49 which I also ran into trying to get started.