### PR TITLE
Docs: Update notice since view transitions just got the status "Baseline newly available" as of Oct 2025

### DIFF
--- a/packages/docs/src/routes/docs/transitions/+page.md
+++ b/packages/docs/src/routes/docs/transitions/+page.md
@@ -6,7 +6,7 @@
 
 # Transitions
 
-> ⚠️ Animotion uses the [View Transitions API (single document)](https://caniuse.com/view-transitions) which is Baseline newly available since Oct 2025. The core presentations features still work in older browsers, but they might not show all transitions.
+> ⚠️ Animotion uses the [View Transitions API (single document)](https://caniuse.com/view-transitions) which is Baseline newly available since Oct 2025. The core presentation features still work in older browsers, but they might not show all transitions.
 
 ## Animating elements
 

--- a/packages/docs/src/routes/docs/transitions/+page.md
+++ b/packages/docs/src/routes/docs/transitions/+page.md
@@ -6,7 +6,7 @@
 
 # Transitions
 
-> ⚠️ The View Transitions API is not supported in Firefox.
+> ⚠️ Animotion uses the [View Transitions API (single document)](https://caniuse.com/view-transitions) which is Baseline newly available since Oct 2025. The core presentations features still work in older browsers, but they might not show all transitions.
 
 ## Animating elements
 

--- a/packages/docs/src/routes/docs/whats-new/+page.md
+++ b/packages/docs/src/routes/docs/whats-new/+page.md
@@ -29,7 +29,7 @@ Animotion is now a standalone package named `@animotion/core`. This makes it eas
 
 Animotion takes advantage of the View Transitions API for layout animations. You can use the `<Transition>` component to assign a `view-transition-name` to an element: 
 
-> ⚠️ The View Transitions API is not supported in Firefox.
+> ⚠️ Animotion uses the [View Transitions API (single document)](https://caniuse.com/view-transitions) which is Baseline newly available since Oct 2025. The core presentations features still work in older browsers, but they might not show all transitions.
 
 ```svelte
 <script>

--- a/packages/docs/src/routes/docs/whats-new/+page.md
+++ b/packages/docs/src/routes/docs/whats-new/+page.md
@@ -29,7 +29,7 @@ Animotion is now a standalone package named `@animotion/core`. This makes it eas
 
 Animotion takes advantage of the View Transitions API for layout animations. You can use the `<Transition>` component to assign a `view-transition-name` to an element: 
 
-> ⚠️ Animotion uses the [View Transitions API (single document)](https://caniuse.com/view-transitions) which is Baseline newly available since Oct 2025. The core presentations features still work in older browsers, but they might not show all transitions.
+> ⚠️ Animotion uses the [View Transitions API (single document)](https://caniuse.com/view-transitions) which is Baseline newly available since Oct 2025. The core presentation features still work in older browsers, but they might not show all transitions.
 
 ```svelte
 <script>


### PR DESCRIPTION
- Update notices
- Also included link to check browser support